### PR TITLE
Add urllib3<2.0 to requirements.txt

### DIFF
--- a/devchat/requirements.txt
+++ b/devchat/requirements.txt
@@ -6,3 +6,4 @@ pytz~=2023.3
 rich_click~=1.6.1
 tiktoken~=0.4.0
 tinydb~=4.7.1
+urllib3<2.0


### PR DESCRIPTION
- Added urllib3 with version constraint <2.0 to devchat/requirements.txt.

Resolve the version mismatch error between urllib3 2.0 and OpenSSL