### PR TITLE
Add finish_reason to OpenAIPrompt response

### DIFF
--- a/devchat/openai/openai_prompt.py
+++ b/devchat/openai/openai_prompt.py
@@ -188,7 +188,7 @@ class OpenAIPrompt(Prompt):
                     delta_content = self.response[0].stream_from_dict(delta)
                 else:
                     self.response[index].stream_from_dict(delta)
-                     
+
             if finish_reason:
                 delta_content += f"\n\nfinish_reason: {finish_reason}"
 

--- a/devchat/openai/openai_prompt.py
+++ b/devchat/openai/openai_prompt.py
@@ -173,6 +173,7 @@ class OpenAIPrompt(Prompt):
         for choice in response_data['choices']:
             delta = choice['delta']
             index = choice['index']
+            finish_reason = choice['finish_reason']
 
             if index >= len(self.response):
                 self.response.extend([None] * (index - len(self.response) + 1))
@@ -187,6 +188,9 @@ class OpenAIPrompt(Prompt):
                     delta_content = self.response[0].stream_from_dict(delta)
                 else:
                     self.response[index].stream_from_dict(delta)
+                     
+            if finish_reason:
+                delta_content += f"\n\nfinish_reason: {finish_reason}"
 
         return delta_content
 


### PR DESCRIPTION
- Extract finish_reason from choice in OpenAIPrompt.
- Append finish_reason to delta_content if present.