### PR TITLE
Fix role check in OpenAIPrompt class

### DIFF
--- a/devchat/openai/openai_prompt.py
+++ b/devchat/openai/openai_prompt.py
@@ -70,7 +70,7 @@ class OpenAIPrompt(Prompt):
                     state = "history_chat"
 
             if state == "history_chat":
-                if message.role in ("user", "assistant"):
+                if message.role in ("user", "assistant", "function"):
                     self._history_messages[Message.CHAT].append(message)
                 else:
                     state = "new_context"
@@ -85,7 +85,7 @@ class OpenAIPrompt(Prompt):
 
         if not self.request:
             last_user_message = self._history_messages[Message.CHAT].pop()
-            if last_user_message.role == "user":
+            if last_user_message.role == "user" or last_user_message.role == "function":
                 self._new_messages["request"] = last_user_message
             else:
                 logger.warning("Invalid user request: %s", last_user_message)

--- a/devchat/openai/openai_prompt.py
+++ b/devchat/openai/openai_prompt.py
@@ -85,7 +85,7 @@ class OpenAIPrompt(Prompt):
 
         if not self.request:
             last_user_message = self._history_messages[Message.CHAT].pop()
-            if last_user_message.role == "user" or last_user_message.role == "function":
+            if last_user_message.role in ("user", "function"):
                 self._new_messages["request"] = last_user_message
             else:
                 logger.warning("Invalid user request: %s", last_user_message)


### PR DESCRIPTION
- Update the role check in the `history_chat` state of the `OpenAIPrompt` class to include the "function" role.
- Previously, the role check only included "user" and "assistant" roles.
- This fix ensures that messages with the "function" role are correctly appended to the history messages.
- Also, update the role check in the `request` assignment to include the "function" role.
- Previously, the role check only included "user" role.
- This fix ensures that the last user message with the "function" role is correctly assigned as the request message.