### PR TITLE
Fix empty filePath return issue in selected_lines function

### DIFF
--- a/devchat/ide/vscode_services.py
+++ b/devchat/ide/vscode_services.py
@@ -136,7 +136,7 @@ def selected_lines():
 
     # continue with the rest of the function
     return {
-        "filePath": "",
+        "filePath": file_path,
         "selectedText": "".join(_selected_lines),
         "selectedRange": [start_line, start_col, end_line, end_col],
     }


### PR DESCRIPTION
This PR addresses the issue where the `selected_lines` function from the `devchat.ide.vscode_services` module was returning an object with an empty `filePath` field. Changes have been made to ensure that the function now correctly populates the `filePath` in the returned object, allowing for proper further processing and integration with development environments.

Closes https://github.com/devchat-ai/devchat/issues/253