### PR TITLE
Feature: Downgrade model validation severity to warnings

### DIFF
--- a/devchat/openai/openai_prompt.py
+++ b/devchat/openai/openai_prompt.py
@@ -232,8 +232,8 @@ class OpenAIPrompt(Prompt):
 
     def _validate_model(self, response_data: dict):
         if not response_data['model'].startswith(self.model):
-            raise ValueError(f"Model mismatch: expected '{self.model}', "
-                             f"got '{response_data['model']}'")
+            logger.warning("Model mismatch: expected '%s', got '%s'",
+                           self.model, response_data['model'])
 
     def _timestamp_from_dict(self, response_data: dict):
         if not self._timestamp:

--- a/tests/test_openai_prompt.py
+++ b/tests/test_openai_prompt.py
@@ -43,37 +43,6 @@ def test_prompt_init_and_set_response():
     assert prompt.responses[0].content == "The 2020 World Series was played in Arlington, Texas."
 
 
-def test_prompt_model_mismatch():
-    name, email = get_user_info()
-    prompt = OpenAIPrompt(model="gpt-3.5-turbo", user_name=name, user_email=email)
-
-    response_str = '''
-    {
-      "choices": [
-        {
-          "finish_reason": "stop",
-          "index": 0,
-          "message": {
-            "content": "\\n\\n1, 2, 3, 4, 5, 6, 7, 8, 9, 10.",
-            "role": "assistant"
-          }
-        }
-      ],
-      "created": 1677825456,
-      "id": "chatcmpl-6ptKqrhgRoVchm58Bby0UvJzq2ZuQ",
-      "model": "gpt-4",
-      "object": "chat.completion",
-      "usage": {
-        "completion_tokens": 301,
-        "prompt_tokens": 36,
-        "total_tokens": 337
-      }
-    }
-    '''
-    with pytest.raises(ValueError):
-        prompt.set_response(response_str)
-
-
 @pytest.fixture(scope="module", name='responses')
 def fixture_responses():
     current_dir = os.path.dirname(__file__)


### PR DESCRIPTION
This PR addresses issue #278 by adjusting the model validation severity from an error to a warning level. The modification will allow our system to log warnings instead of errors when there is a discrepancy between the requested and the received model from OpenAI's API.

Changes included:
- Updated validation logic to emit warnings instead of raising exceptions.
- Enhanced operational stability to accommodate model discrepancies.
- Increased system flexibility for future model updates from OpenAI.

This change aligns with the proposed solution in the original issue, aiming to improve system resilience and reduce unnecessary disruptions in service due to strict model validation.

By merging this PR, we can expect an improved integration experience with OpenAI's API that gracefully handles model updates and reduces the chance of service interruptions.

Closes devchat-ai/devchat#278.