### PR TITLE
Fix README Error Marking When Workflow Triggered Without User Input

### DIFF
--- a/devchat/engine/command_runner.py
+++ b/devchat/engine/command_runner.py
@@ -179,7 +179,7 @@ class CommandRunner:
         )
         readme_content = self.__get_readme(command)
         if readme_content:
-            print(readme_content, file=sys.stderr, flush=True)
+            print(readme_content, flush=True)
         else:
             print(input_miss_error, file=sys.stderr, flush=True)
         return True
@@ -200,7 +200,7 @@ class CommandRunner:
 
         readme_content = self.__get_readme(command)
         if readme_content:
-            print(readme_content, file=sys.stderr, flush=True)
+            print(readme_content, flush=True)
         else:
             print("Missing parameters:", missed_parameters, file=sys.stderr, flush=True)
         return True


### PR DESCRIPTION
This pull request addresses the issue reported in devchat-ai/devchat#313, where the README was incorrectly marked with an error when a workflow requiring user input was triggered without it. The changes made ensure that the README is now displayed normally, without any inaccurate error indications, aligning with the expected behavior outlined in the issue.

The following improvements were made:
- README is now shown normally without redirecting to the error stream.
- User experience is enhanced by eliminating misleading error markings.
- Compliance with expected output as documented in the issue.

Closes devchat-ai/devchat#313.