### PR TITLE
Fix chat_json decorator PROMPT mutation in devchat

### DIFF
--- a/devchat/llm/chat.py
+++ b/devchat/llm/chat.py
@@ -49,10 +49,10 @@ def chat(
         @wraps(func)
         def wrapper(*args, **kwargs): # pylint: disable=unused-argument
             nonlocal prompt, memory, model, llm_config
-            prompt = prompt.format(**kwargs)
+            prompt_new = prompt.format(**kwargs)
             messages = memory.contexts() if memory else []
-            if not any(item["content"] == prompt for item in messages) and prompt:
-                messages.append({"role": "user", "content": prompt})
+            if not any(item["content"] == prompt_new for item in messages) and prompt_new:
+                messages.append({"role": "user", "content": prompt_new})
             if "__user_request__" in kwargs:
                 messages.append(kwargs["__user_request__"])
                 del kwargs["__user_request__"]
@@ -68,7 +68,7 @@ def chat(
 
             if memory:
                 memory.append(
-                    {"role": "user", "content": prompt},
+                    {"role": "user", "content": prompt_new},
                     {"role": "assistant", "content": response["content"]},
                 )
             return response["content"]
@@ -88,10 +88,10 @@ def chat_json(
         @wraps(func)
         def wrapper(*args, **kwargs): # pylint: disable=unused-argument
             nonlocal prompt, memory, model, llm_config
-            prompt = prompt.format(**kwargs)
+            prompt_new = prompt.format(**kwargs)
             messages = memory.contexts() if memory else []
-            if not any(item["content"] == prompt for item in messages):
-                messages.append({"role": "user", "content": prompt})
+            if not any(item["content"] == prompt_new for item in messages):
+                messages.append({"role": "user", "content": prompt_new})
 
             llm_config["model"] = model
             response = chat_completion_no_stream_return_json(messages, llm_config=llm_config)
@@ -100,7 +100,7 @@ def chat_json(
 
             if memory:
                 memory.append(
-                    {"role": "user", "content": prompt},
+                    {"role": "user", "content": prompt_new},
                     {"role": "assistant", "content": json.dumps(response)},
                 )
             return response

--- a/tests/test_cli_prompt.py
+++ b/tests/test_cli_prompt.py
@@ -184,7 +184,9 @@ def test_prompt_with_function_replay(git_repo, functions_file):  # pylint: disab
 
     content = get_content(result.output)
     assert result.exit_code == 0
-    assert 'get_current_weather' in content or 'GetCurrentWeather' in content
+    assert 'get_current_weather' in content \
+        or 'GetCurrentWeather' in content \
+        or 'getCurrentWeather' in content
 
 
 def test_prompt_without_repo(mock_home_dir):  # pylint: disable=W0613


### PR DESCRIPTION
This PR addresses the issue where the `chat_json` decorator would inadvertently mutate the `PROMPT` template variable during multiple invocations within the devchat application, leading to inconsistent behavior as documented in issue [#354](https://github.com/devchat-ai/devchat/issues/354).

The proposed changes introduce a new variable `prompt_new` to hold the intermediary states, ensuring that the original `PROMPT` template remains unaffected across function calls. Both `chat` and `chat_json` functions have been updated to make use of `prompt_new`, providing a consistent and predictable outcome regardless of the number of invocations.

Closes devchat-ai/devchat#354.