### PR TITLE
fix: Enhance content_to_json for backward compatibility

### DIFF
--- a/devchat/llm/openai.py
+++ b/devchat/llm/openai.py
@@ -123,7 +123,8 @@ def chunks_call(chunks):
 
 def content_to_json(content):
     try:
-        response_obj = json.loads(content)
+        content_no_block = _try_remove_markdown_block_flag(content)
+        response_obj = json.loads(content_no_block)
         return response_obj
     except json.JSONDecodeError as err:
         raise RetryException(err) from err


### PR DESCRIPTION
This PR includes modifications to the `content_to_json` function that allow it to handle non-JSON content gracefully. A helper function `_try_remove_markdown_block_flag` has been introduced to preprocess content for compatibility with older versions of the devchat-api.
