### PR TITLE
Refactor main entrypoint to disable windows_expand_args

### DIFF
--- a/devchat/__main__.py
+++ b/devchat/__main__.py
@@ -3,4 +3,4 @@ import sys
 if __name__ == "__main__":
     from devchat._cli.main import main as _main
 
-    sys.exit(_main())
+    sys.exit(_main(windows_expand_args=False))


### PR DESCRIPTION
Refactoring `__main__.py` to disable `windows_expand_args` in the `_main` function for better command-line argument handling on Windows systems.